### PR TITLE
feat: add extraLabels

### DIFF
--- a/templates/deployment-registry.yaml
+++ b/templates/deployment-registry.yaml
@@ -5,15 +5,24 @@ metadata:
   name: {{ include "apicurio-registry.name" . }}
   labels:
     {{- include "apicurio-registry.labels" . | nindent 4 }}
+    {{- with .Values.registry.extraLabels  }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
       {{- include "apicurio-registry.selectorLabels" . | nindent 6 }}
+      {{- with .Values.registry.extraLabels  }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
       app.kubernetes.io/component: registry
   template:
     metadata:
       labels:
         {{- include "apicurio-registry.selectorLabels" . | nindent 8 }}
+        {{- with .Values.registry.extraLabels  }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         app.kubernetes.io/component: registry
     spec:
       serviceAccountName: {{ include "apicurio-registry.name" . }}

--- a/templates/deployment-sync.yaml
+++ b/templates/deployment-sync.yaml
@@ -5,15 +5,24 @@ metadata:
   name: {{ include "apicurio-registry.name" . }}-sync
   labels:
     {{- include "apicurio-registry.labels" . | nindent 4 }}
+    {{- with .Values.sync.extraLabels  }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
       {{- include "apicurio-registry.selectorLabels" . | nindent 6 }}
+      {{- with .Values.sync.extraLabels  }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
       app.kubernetes.io/component: sync
   template:
     metadata:
       labels:
         {{- include "apicurio-registry.selectorLabels" . | nindent 8 }}
+        {{- with .Values.sync.extraLabels  }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         app.kubernetes.io/component: sync
     spec:
       serviceAccountName: {{ include "apicurio-registry.name" . }}

--- a/test/lint/registry.yaml
+++ b/test/lint/registry.yaml
@@ -63,3 +63,13 @@ tests:
             values don't meet the specifications of the schema(s) in the following chart(s):
             apicurio-registry:
             - registry.ingress.ingressClassName: Invalid type. Expected: string, given: integer
+  - it: extraLabels is not object
+    set:
+      registry:
+          extraLabels: 1
+    asserts:
+      - failedTemplate:
+          errorMessage: |
+            values don't meet the specifications of the schema(s) in the following chart(s):
+            apicurio-registry:
+            - registry.extraLabels: Invalid type. Expected: object, given: integer

--- a/test/lint/sync.yaml
+++ b/test/lint/sync.yaml
@@ -2,6 +2,16 @@ suite: lint sync values
 templates:
   - fake.yaml
 tests:
+  - it: extraLabels is not object
+    set:
+      sync:
+        extraLabels: 1
+    asserts:
+      - failedTemplate:
+          errorMessage: |
+            values don't meet the specifications of the schema(s) in the following chart(s):
+            apicurio-registry:
+            - sync.extraLabels: Invalid type. Expected: object, given: integer
   - it: nodeSelector is not object
     set:
       sync:

--- a/test/unit/deployment_registry.yaml
+++ b/test/unit/deployment_registry.yaml
@@ -141,3 +141,32 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[3].valueFrom.secretKeyRef.key
           value: baz
+  - it: no extraLabels
+    set:
+      registry:
+        extraLabels:
+          testLabel: "myLabel"
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value: 
+            app.kubernetes.io/component: registry
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: apicurio-registry
+            testLabel: myLabel
+      - equal:
+          path: metadata.labels
+          value: 
+            helm.sh/chart: "apicurio-registry-0.0.0"
+            app.kubernetes.io/version: "0.0.0"
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: apicurio-registry
+            app.kubernetes.io/instance: RELEASE-NAME
+            testLabel: myLabel
+      - equal:
+          path: spec.template.metadata.labels
+          value: 
+            app.kubernetes.io/component: registry
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: apicurio-registry
+            testLabel: myLabel

--- a/test/unit/deployment_sync.yaml
+++ b/test/unit/deployment_sync.yaml
@@ -109,3 +109,54 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].env[0].value
           value: VALUE
+  - it: no extraLabels
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value: 
+            app.kubernetes.io/component: sync
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: apicurio-registry
+      - equal:
+          path: metadata.labels
+          value: 
+            helm.sh/chart: "apicurio-registry-0.0.0"
+            app.kubernetes.io/version: "0.0.0"
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: apicurio-registry
+            app.kubernetes.io/instance: RELEASE-NAME
+      - equal:
+          path: spec.template.metadata.labels
+          value: 
+            app.kubernetes.io/component: sync
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: apicurio-registry
+  - it: with extraLabels
+    set:
+      sync:
+        extraLabels:
+          testLabel: "myLabel"
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value: 
+            app.kubernetes.io/component: sync
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: apicurio-registry
+            testLabel: myLabel
+      - equal:
+          path: metadata.labels
+          value: 
+            helm.sh/chart: "apicurio-registry-0.0.0"
+            app.kubernetes.io/version: "0.0.0"
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: apicurio-registry
+            app.kubernetes.io/instance: RELEASE-NAME
+            testLabel: myLabel
+      - equal:
+          path: spec.template.metadata.labels
+          value: 
+            app.kubernetes.io/component: sync
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: apicurio-registry
+            testLabel: myLabel

--- a/values.schema.json
+++ b/values.schema.json
@@ -55,6 +55,9 @@
     "volumes": {
       "type": "array", "default": []
     },
+    "labels": {
+      "type": "object", "default": {}
+    },
     "ingress": {
       "type": "object", "title": "ingress resource for registry",
       "required": ["enabled", "host", "path"],
@@ -102,7 +105,8 @@
         "extraVolumes": {"$ref": "#/definitions/volumes", "title": "extra volumes for registry"},
         "kafka": {"$ref": "#/definitions/persistence/kafka"},
         "sql": {"$ref": "#/definitions/persistence/sql"},
-        "ingress": {"$ref": "#/definitions/ingress"}
+        "ingress": {"$ref": "#/definitions/ingress"},
+        "extraLabels": {"$ref": "#/definitions/labels", "title": "deployment and pod resources labels for registry"}
       }
     },
     "sync": {
@@ -116,7 +120,8 @@
         "resources": {"$ref": "#/definitions/podResources"},
         "extraVolumeMounts": {"$ref": "#/definitions/volumeMounts", "title": "extra volume mounts for registry content sync"},
         "extraVolumes": {"$ref": "#/definitions/volumes", "title": "extra volumes for registry content sync"},
-        "registryUrl": {"type": ["null", "string"], "default": null}
+        "registryUrl": {"type": ["null", "string"], "default": null},
+        "extraLabels": {"$ref": "#/definitions/labels", "title": "deployment and pod resources labels for sync"}
       }
     }
   }

--- a/values.yaml
+++ b/values.yaml
@@ -40,6 +40,8 @@ registry:
     # - name: kafkauser
     #   secret:
     #     secretName: kafka-user
+  # add extraLabels in deployment and pod objects
+  extraLabels: {}
 
   ingress:
     enabled: false
@@ -78,4 +80,5 @@ sync:
     # - name: kafkauser
     #   secret:
     #     secretName: kafka-user
-
+  # add extraLabels in deployment and pod objects
+  extraLabels: {}


### PR DESCRIPTION
On this PR i've added `extraLabels` field, the goal is to custom labels in deployement and pod object. 

Test:

```shell
helm plugin ls | grep unittest || helm plugin install https://github.com/helm-unittest/helm-unittest.git
unittest	0.3.6  	Unit test for helm chart in YAML with ease to keep your chart functional and robust.
helm unittest -f 'test/lint/*.yaml' .

### Chart [ apicurio-registry ] .

2023/11/29 09:54:54 warning: cannot overwrite table with non table for apicurio-registry.registry.nodeSelector (map[])
2023/11/29 09:54:54 warning: cannot overwrite table with non table for apicurio-registry.registry.ingress (map[annotations:map[] enabled:false host:apicurio.local ingressClassName: labels:map[] path:/ tls:false])
2023/11/29 09:54:54 warning: cannot overwrite table with non table for apicurio-registry.registry.extraLabels (map[])
 PASS  lint registry values	test/lint/registry.yaml
2023/11/29 09:54:54 warning: cannot overwrite table with non table for apicurio-registry.sync.extraLabels (map[])
2023/11/29 09:54:54 warning: cannot overwrite table with non table for apicurio-registry.sync.nodeSelector (map[])
 PASS  lint sync values	test/lint/sync.yaml

Charts:      1 passed, 1 total
Test Suites: 2 passed, 2 total
Tests:       12 passed, 12 total
Snapshot:    0 passed, 0 total
Time:        13.849969ms

helm unittest -f 'test/unit/*.yaml' .

### Chart [ apicurio-registry ] .

 PASS  test deployment-registry.yaml template	test/unit/deployment_registry.yaml
 PASS  test deployment-sync.yaml template	test/unit/deployment_sync.yaml
 PASS  test ingress	test/unit/ingress.yaml
 PASS  test sa	test/unit/sa.yaml

Charts:      1 passed, 1 total
Test Suites: 4 passed, 4 total
Tests:       26 passed, 26 total
Snapshot:    0 passed, 0 total
Time:        52.558546ms

```